### PR TITLE
reset overwritten source files to solve "checkout aborting" after a previous build

### DIFF
--- a/exec-core/src/main/java/com/networknt/bot/core/Constants.java
+++ b/exec-core/src/main/java/com/networknt/bot/core/Constants.java
@@ -6,6 +6,7 @@ public class Constants {
     public static final String COMMENT = "comment";
     public static final String CHECKOUT = "checkout";
     public static final String BRANCH = "branch";
+    public static final String SOURCE_FILES_TO_RESET = "reset_source_files";
     public static final String REPOSITORY = "repository";
     public static final String BUILD = "build";
     public static final String PROJECT = "project";

--- a/exec-develop-build/src/main/java/com/networknt/bot/develop/DevelopBuildTask.java
+++ b/exec-develop-build/src/main/java/com/networknt/bot/develop/DevelopBuildTask.java
@@ -142,6 +142,7 @@ public class DevelopBuildTask implements Command {
 		for (Map<String, Object> repoGroup : namedCheckout) {
 			// get the branch and the list of repositories
 			String branch = (String) repoGroup.get(Constants.BRANCH);
+			List<String> sourceFilesToReset = (List<String>) repoGroup.get(Constants.SOURCE_FILES_TO_RESET);
 
 			// check whether this task must be skipped
 			if ((Boolean) repoGroup.get(Constants.SKIP))
@@ -166,8 +167,17 @@ public class DevelopBuildTask implements Command {
 					List<String> commands = new ArrayList<>();
 					commands.add("bash");
 					commands.add("-c");
-					commands.add("git checkout " + branch + " ; git pull origin " + branch);
-					logger.info("git checkout " + branch + " ; git pull origin " + branch + " for " + rPath);
+					String gitCommands = "git checkout " + branch + " ; ";
+					System.out.println("Reset Files");
+					System.out.println(sourceFilesToReset);
+					if (sourceFilesToReset != null) {
+						for (String file : sourceFilesToReset) {
+							gitCommands += "test -f " + file + " && git checkout " + file + " ; ";
+						}
+					}
+					gitCommands += "git pull origin " + branch;
+					commands.add(gitCommands);
+					logger.info(gitCommands + " for " + rPath);
 					result = executor.execute(commands, rPath.toFile());
 					StringBuilder stdout = executor.getStdout();
 					if (stdout != null && stdout.length() > 0)


### PR DESCRIPTION
Hi Dan, this is to make build-all a little bit easier. A status file merge from a previous build will prevent a complete checkout of the same repo in the same directory.